### PR TITLE
layout-invalidate 동작 구조 개선

### DIFF
--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentImageView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentImageView.java
@@ -19,6 +19,7 @@ class PageContentImageView extends View {
     private ImageView.ScaleType scaleType;
     private Rect rect = new Rect();
     private boolean isHighQualityView;
+    private boolean didDrawOnce;
 
     PageContentImageView(Context context) {
         this(context, null);
@@ -47,6 +48,7 @@ class PageContentImageView extends View {
         }
         this.bitmap = bitmap;
         this.bitmapSet = (bitmap != null);
+        this.didDrawOnce = false;
     }
 
     @Override
@@ -59,9 +61,7 @@ class PageContentImageView extends View {
             rect.set(left, top, right, bottom);
         }
 
-        Log.d("PageContentImageView", "onLayout changed=" + changed + " rect=" + rect.toString());
-
-        if (changed) {
+        if (bitmapSet && changed && !didDrawOnce) {
             invalidate();
         }
     }
@@ -74,6 +74,7 @@ class PageContentImageView extends View {
 
         if (bitmapSet) {
             canvas.drawBitmap(bitmap, null, rect, null);
+            didDrawOnce = true;
         }
     }
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentImageView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentImageView.java
@@ -1,0 +1,79 @@
+package com.ridi.books.viewer.reader.pagecontent;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.os.AsyncTask;
+import android.support.annotation.ColorInt;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.View;
+import android.widget.ImageView;
+
+class PageContentImageView extends View {
+    private boolean bitmapSet;
+    private Bitmap bitmap;
+    @ColorInt private int paperColor;
+    private ImageView.ScaleType scaleType;
+    private Rect rect = new Rect();
+    private boolean isHighQualityView;
+
+    PageContentImageView(Context context) {
+        this(context, null);
+    }
+
+    PageContentImageView(Context context, boolean isHighQualityView) {
+        this(context, null);
+        this.isHighQualityView = isHighQualityView;
+    }
+
+    private PageContentImageView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public void setPaperColor(@ColorInt int paperColor) {
+        this.paperColor = paperColor;
+    }
+
+    public void setScaleType(ImageView.ScaleType scaleType) {
+        this.scaleType = scaleType;
+    }
+
+    public void setImageBitmap(Bitmap bitmap) {
+        if (this.bitmap != null) {
+            this.bitmap.recycle();
+        }
+        this.bitmap = bitmap;
+        this.bitmapSet = (bitmap != null);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+
+        if (isHighQualityView) {
+            rect.set(0, 0, right - left, bottom - top);
+        } else {
+            rect.set(left, top, right, bottom);
+        }
+
+        Log.d("PageContentImageView", "onLayout changed=" + changed + " rect=" + rect.toString());
+
+        if (changed) {
+            invalidate();
+        }
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        canvas.drawColor(paperColor);
+
+        if (bitmapSet) {
+            canvas.drawBitmap(bitmap, null, rect, null);
+        }
+    }
+}

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentImageView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentImageView.java
@@ -3,31 +3,25 @@ package com.ridi.books.viewer.reader.pagecontent;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.Paint;
 import android.graphics.Rect;
-import android.os.AsyncTask;
 import android.support.annotation.ColorInt;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.View;
-import android.widget.ImageView;
 
 class PageContentImageView extends View {
-    private boolean bitmapSet;
     private Bitmap bitmap;
     @ColorInt private int paperColor;
-    private ImageView.ScaleType scaleType;
     private Rect rect = new Rect();
-    private boolean isHighQualityView;
-    private boolean didDrawOnce;
+    private boolean highQualityView;
+    private boolean dirty;
 
     PageContentImageView(Context context) {
-        this(context, null);
+        this(context, false);
     }
 
-    PageContentImageView(Context context, boolean isHighQualityView) {
+    PageContentImageView(Context context, boolean highQualityView) {
         this(context, null);
-        this.isHighQualityView = isHighQualityView;
+        this.highQualityView = highQualityView;
     }
 
     private PageContentImageView(Context context, AttributeSet attrs) {
@@ -38,30 +32,22 @@ class PageContentImageView extends View {
         this.paperColor = paperColor;
     }
 
-    public void setScaleType(ImageView.ScaleType scaleType) {
-        this.scaleType = scaleType;
-    }
-
     public void setImageBitmap(Bitmap bitmap) {
-        if (this.bitmap != null) {
-            this.bitmap.recycle();
-        }
         this.bitmap = bitmap;
-        this.bitmapSet = (bitmap != null);
-        this.didDrawOnce = false;
+        dirty = true;
     }
 
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
 
-        if (isHighQualityView) {
+        if (highQualityView) {
             rect.set(0, 0, right - left, bottom - top);
         } else {
             rect.set(left, top, right, bottom);
         }
 
-        if (bitmapSet && changed && !didDrawOnce) {
+        if ((bitmap != null) && changed && dirty) {
             invalidate();
         }
     }
@@ -72,9 +58,9 @@ class PageContentImageView extends View {
 
         canvas.drawColor(paperColor);
 
-        if (bitmapSet) {
+        if (bitmap != null) {
             canvas.drawBitmap(bitmap, null, rect, null);
-            didDrawOnce = true;
+            dirty = false;
         }
     }
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -503,15 +503,12 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
             measureView(childViews.valueAt(i));
         }
     }
-    
-    @Override
-    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        super.onLayout(changed, left, top, right, bottom);
 
+    private void doLayout() {
         if (currentIndex == PageContentView.NO_INDEX) {
             return;
         }
-        
+
         PageContentView cv = childViews.get(currentIndex);
         Point cvOffset;
 
@@ -519,21 +516,21 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
             scale = requestedScale;
             requestedScale = DEFAULT_SCALE;
         }
-        
+
         if (!resetLayout) {
             // Move to next or previous if current is sufficiently off center
             if (cv != null && scrollMode && !sliding) {
                 cvOffset = subScreenSizeOffset(cv);
                 if (cv.getTop() + cv.getMeasuredHeight() + cvOffset.y
-                        + pageGapPixels * scale / 2 + scrollOffsetY < getHeight() / 2) {
+                    + pageGapPixels * scale / 2 + scrollOffsetY < getHeight() / 2) {
                     setCurrentIndexToRightOrDown();
                 }
                 if (cv.getTop() - cvOffset.y
-                        - pageGapPixels * scale / 2 + scrollOffsetY >= getHeight() / 2) {
+                    - pageGapPixels * scale / 2 + scrollOffsetY >= getHeight() / 2) {
                     setCurrentIndexToLeftOrUp();
                 }
             }
-            
+
             // Remove not needed children and hold them for reuse
             for (int i = childViews.size() - 1; i >= 0; i--) {
                 int index = childViews.keyAt(i);
@@ -589,12 +586,12 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
                 cvTop  = cv.getTop()  + scrollOffsetY;
             }
         }
-        
+
         // Scroll values have been accounted for
         scrollOffsetX = scrollOffsetY = 0;
         cvRight  = cvLeft + cv.getMeasuredWidth();
         cvBottom = cvTop  + cv.getMeasuredHeight();
-        
+
         if (scrollMode) {
             if (!isLeftOrUpIndexAvailable() && cvTop > cvOffset.y) {
                 cvTop = cvOffset.y;
@@ -645,7 +642,7 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
                 }
             }
         }
-        
+
         if (!userInteracting && scroller.isFinished()) {
             Point corr = getCorrection(getScrollBounds(cvLeft, cvTop, cvRight, cvBottom));
             cvRight  += corr.x;
@@ -665,7 +662,7 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
             cvLeft   += corr.x;
             cvRight  += corr.x;
         }
-        
+
         cv.layout(cvLeft, cvTop, cvRight, cvBottom);
 
         if (scrollMode) {
@@ -767,6 +764,13 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
                 rv.layout(rvLeft, rvTop, rvRight, rvBottom);
             }
         }
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+
+        doLayout();
 
         invalidate();
     }
@@ -1275,7 +1279,7 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
                 slideViewOntoScreen(view);
             }
         } else {
-            requestLayout();
+            doLayout();
             post(scrollProcessor);
         }
     }
@@ -1305,7 +1309,7 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
                 slideViewOntoScreen(view);
             }
         } else {
-            requestLayout();
+            doLayout();
             post(scrollProcessor);
         }
     }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -847,9 +847,6 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
             }
             touchStartOffset = null;
         }
-        
-        requestLayout();
-        
         return true;
     }
     

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
@@ -22,10 +22,10 @@ class PageContentView extends ViewGroup {
     
     private PageContent pageContent;
     private AsyncTask<Void, Void, PageContent> contentLoadTask;
-    
-    private ImageView fullView;
+
+    private PageContentImageView fullView;
     private AsyncTask<Void, Void, Bitmap> fullRenderingTask;
-    private ImageView hqView;  // high quality view
+    private PageContentImageView hqView;  // high quality view
     private AsyncTask<HighQualityInfo, Void, HighQualityInfo> hqRenderingTask;
     private HighQualityInfo hqInfo;
     private BitmapPostProcessor postProcessor;
@@ -44,8 +44,8 @@ class PageContentView extends ViewGroup {
         this.postProcessor = postProcessor;
 
         size = canvasSize;
-        fullView = new ImageView(context);
-        fullView.setBackgroundColor(paperColor);
+        fullView = new PageContentImageView(context);
+        fullView.setPaperColor(paperColor);
         fullView.setVisibility(INVISIBLE);
         fullView.setScaleType(ImageView.ScaleType.FIT_CENTER);
         addView(fullView);
@@ -260,8 +260,8 @@ class PageContentView extends ViewGroup {
 
             // Create and add the image view if not already done
             if (hqView == null) {
-                hqView = new ImageView(getContext());
-                hqView.setBackgroundColor(paperColor);
+                hqView = new PageContentImageView(getContext(), true);
+                hqView.setPaperColor(paperColor);
                 hqView.setVisibility(INVISIBLE);
                 hqView.setScaleType(ImageView.ScaleType.FIT_CENTER);
                 addView(hqView);
@@ -294,7 +294,7 @@ class PageContentView extends ViewGroup {
                         hqInfo = result;
                         hqView.setImageBitmap(result.bitmap);
                         hqView.setVisibility(VISIBLE);
-                        
+
                         // Calling requestLayout here doesn't lead to a later call to layout. No idea
                         // why, but apparently others have run into the problem.
                         hqView.layout(hqInfo.area.left, hqInfo.area.top, hqInfo.area.right, hqInfo.area.bottom);

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
@@ -7,7 +7,6 @@ import android.os.AsyncTask;
 import android.support.annotation.ColorInt;
 import android.util.AttributeSet;
 import android.view.ViewGroup;
-import android.widget.ImageView;
 
 class PageContentView extends ViewGroup {
     static final int NO_INDEX = Integer.MIN_VALUE;
@@ -47,7 +46,6 @@ class PageContentView extends ViewGroup {
         fullView = new PageContentImageView(context);
         fullView.setPaperColor(paperColor);
         fullView.setVisibility(INVISIBLE);
-        fullView.setScaleType(ImageView.ScaleType.FIT_CENTER);
         addView(fullView);
     }
 
@@ -261,7 +259,6 @@ class PageContentView extends ViewGroup {
                 hqView = new PageContentImageView(getContext(), true);
                 hqView.setPaperColor(paperColor);
                 hqView.setVisibility(INVISIBLE);
-                hqView.setScaleType(ImageView.ScaleType.FIT_CENTER);
                 addView(hqView);
             }
 

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
@@ -211,7 +211,8 @@ class PageContentView extends ViewGroup {
                 fullView.setImageBitmap(result);
                 fullView.setVisibility(VISIBLE);
                 rendered = true;
-                invalidate();
+
+                requestLayout();
             }
             
             @Override
@@ -221,8 +222,6 @@ class PageContentView extends ViewGroup {
         };
 
         fullRenderingTask.execute();
-        
-        requestLayout();
     }
     
     void updateHighQuality() {
@@ -294,10 +293,7 @@ class PageContentView extends ViewGroup {
                         hqView.setImageBitmap(result.bitmap);
                         hqView.setVisibility(VISIBLE);
 
-                        // Calling requestLayout here doesn't lead to a later call to layout. No idea
-                        // why, but apparently others have run into the problem.
-                        hqView.layout(hqInfo.area.left, hqInfo.area.top, hqInfo.area.right, hqInfo.area.bottom);
-                        invalidate();
+                        requestLayout();
                     }
                 }
             };

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
@@ -118,7 +118,6 @@ class PageContentView extends ViewGroup {
         }
         
         setMeasuredDimension(width, height);
-        requestLayout();
     }
 
     @Override


### PR DESCRIPTION
기존 동작구조상 필요 이상으로 `View.requestLayout()`이 호출되고 있으며
그로 인해 필요 이상으로 빈번하게 `View.invalidate()`가 발생하고 있습니다.

일차적으로 `5e7f833` 커밋을 반영한 PP1 펌웨어로 테스트해본 결과
* 페이지 넘김 및 확대/축소 시 반응성개선,
* 페이지 넘길 때의 전류 소모량이 감소되는 결과를 확인할 수 있었습니다