### PR TITLE
PageContent에서 외부 링크를 제공받을수 있도록 link 추가

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{java,kt}]
+charset = utf-8
+indent_size = 4
+continuation_indent_size = 4
+max_line_length = 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-27.0.3
-    - android-27
+    - build-tools-28.0.3
+    - android-28
 
 script: ./gradlew assembleRelease
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
     - build-tools-28.0.3
     - android-28
 
-script: ./gradlew assembleRelease
+script: ./gradlew check
 
 notifications:
   email: false

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
 
 group = 'com.github.ridi'
-version = '1.3.2'
+version = '1.3.3-dev'
 
 configurations {
     ktlint

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
 repositories {
     jcenter()
     google()
+    maven { url 'https://jitpack.io' }
 }
 
 apply plugin: 'com.android.library'

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 buildscript {
+    ext.kotlin_version = '1.3.10'
     repositories {
         jcenter()
         google()
@@ -6,6 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -15,10 +17,15 @@ repositories {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
 
 group = 'com.github.ridi'
 version = '1.3.2'
+
+configurations {
+    ktlint
+}
 
 android {
     compileSdkVersion 27
@@ -34,11 +41,34 @@ android {
 
 dependencies {
     implementation 'com.android.support:support-annotations:27.1.1'
+
+    ktlint 'com.github.shyiko:ktlint:0.29.0'
+    ktlint 'com.github.ridi:ktlint-ruleset:master-SNAPSHOT'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier = 'sources'
+}
+
+afterEvaluate { project ->
+    check.dependsOn ktlint
+}
+
+task ktlintFormat(type: JavaExec, group: 'formatting') {
+    description = 'Fix Kotlin code style deviations.'
+    classpath = configurations.ktlint
+    main = 'com.github.shyiko.ktlint.Main'
+    args '-F', 'src/**/*.kt'
+}
+
+
+task ktlint(type: JavaExec, group: 'verification') {
+    description = 'Check Kotlin code style.'
+    classpath = configurations.ktlint
+    main = 'com.github.shyiko.ktlint.Main'
+    args 'src/**/*.kt'
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
@@ -17,19 +17,15 @@ repositories {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'kotlin-android'
 
 group = 'com.github.ridi'
-version = '1.3.3-dev'
-
-configurations {
-    ktlint
-}
+version = '1.3.2'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 15
@@ -39,17 +35,25 @@ android {
     }
 }
 
+configurations {
+    ktlint
+}
+
 dependencies {
-    implementation 'com.android.support:support-annotations:27.1.1'
+    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     ktlint 'com.github.shyiko:ktlint:0.29.0'
     ktlint 'com.github.ridi:ktlint-ruleset:master-SNAPSHOT'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier = 'sources'
+}
+
+artifacts {
+    archives sourcesJar
 }
 
 afterEvaluate { project ->
@@ -69,10 +73,6 @@ task ktlint(type: JavaExec, group: 'verification') {
     classpath = configurations.ktlint
     main = 'com.github.shyiko.ktlint.Main'
     args 'src/**/*.kt'
-}
-
-artifacts {
-    archives sourcesJar
 }
 
 install {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jul 25 16:11:52 KST 2018
+#Tue Dec 11 10:47:42 KST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
@@ -94,7 +94,7 @@ public class DoublePageContent implements PageContent {
         ArrayList<PageLink> linkList = new ArrayList<>();
         linkList.addAll(leftPage.getPageLinkList());
         linkList.addAll(
-                verticalOffsetPageLinkList(
+                horizontalOffsetPageLinkList(
                         rightPage.getPageLinkList(),
                         leftPage.getSize().width
                 )
@@ -102,7 +102,7 @@ public class DoublePageContent implements PageContent {
         return linkList;
     }
 
-    private List<PageLink> verticalOffsetPageLinkList(List<PageLink> linkList, float offsetX) {
+    private List<PageLink> horizontalOffsetPageLinkList(List<PageLink> linkList, float offsetX) {
         ArrayList<PageLink> copiedList = new ArrayList<>(linkList);
         for (PageLink pageLink : copiedList) {
             RectF rect = new RectF(pageLink.getBoundingRect());

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
@@ -96,7 +96,7 @@ public class DoublePageContent implements PageContent {
         linkList.addAll(
                 horizontalOffsetLinkList(
                         rightPage.getLinkList(),
-                        size.width / 2
+                        leftPage.getSize().width
                 )
         );
         return linkList;

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
@@ -91,7 +91,7 @@ public class DoublePageContent implements PageContent {
 
     @Override
     public List<PageLink> getPageLinkList() {
-        ArrayList<PageLink> linkList = new ArrayList<>();
+        List<PageLink> linkList = new ArrayList<>();
         linkList.addAll(leftPage.getPageLinkList());
         linkList.addAll(
                 horizontalOffsetPageLinkList(
@@ -103,7 +103,7 @@ public class DoublePageContent implements PageContent {
     }
 
     private List<PageLink> horizontalOffsetPageLinkList(List<PageLink> linkList, float offsetX) {
-        ArrayList<PageLink> copiedList = new ArrayList<>(linkList);
+        List<PageLink> copiedList = new ArrayList<>(linkList);
         for (PageLink pageLink : copiedList) {
             RectF rect = new RectF(pageLink.getBoundingRect());
             rect.offset(offsetX, 0f);

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
@@ -96,7 +96,7 @@ public class DoublePageContent implements PageContent {
         linkList.addAll(
                 horizontalOffsetPageLinkList(
                         rightPage.getPageLinkList(),
-                        leftPage.getSize().width
+                        size.width / 2
                 )
         );
         return linkList;

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
@@ -4,6 +4,8 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 
+import java.util.List;
+
 public class DoublePageContent implements PageContent {
     private final PageContent leftPage;
     private final PageContent rightPage;
@@ -83,5 +85,11 @@ public class DoublePageContent implements PageContent {
         }
 
         return bitmap;
+    }
+
+    @Override
+    public List<PageLink> getPageLinkList() {
+        // TODO : 좌표를 계산해 left right 페이지의 link 들을 리턴해야함.
+        return null;
     }
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
@@ -90,24 +90,24 @@ public class DoublePageContent implements PageContent {
     }
 
     @Override
-    public List<PageLink> getPageLinkList() {
-        List<PageLink> linkList = new ArrayList<>();
-        linkList.addAll(leftPage.getPageLinkList());
+    public List<Link> getLinkList() {
+        List<Link> linkList = new ArrayList<>();
+        linkList.addAll(leftPage.getLinkList());
         linkList.addAll(
-                horizontalOffsetPageLinkList(
-                        rightPage.getPageLinkList(),
+                horizontalOffsetLinkList(
+                        rightPage.getLinkList(),
                         size.width / 2
                 )
         );
         return linkList;
     }
 
-    private List<PageLink> horizontalOffsetPageLinkList(List<PageLink> linkList, float offsetX) {
-        List<PageLink> copiedList = new ArrayList<>(linkList);
-        for (PageLink pageLink : copiedList) {
-            RectF rect = new RectF(pageLink.getBoundingRect());
+    private List<Link> horizontalOffsetLinkList(List<Link> linkList, float offsetX) {
+        List<Link> copiedList = new ArrayList<>(linkList);
+        for (Link link : copiedList) {
+            RectF rect = new RectF(link.getBoundingRect());
             rect.offset(offsetX, 0f);
-            pageLink.setBoundingRect(rect);
+            link.setBoundingRect(rect);
         }
         return copiedList;
     }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
@@ -3,7 +3,9 @@ package com.ridi.books.viewer.reader.pagecontent;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Rect;
+import android.graphics.RectF;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class DoublePageContent implements PageContent {
@@ -89,7 +91,25 @@ public class DoublePageContent implements PageContent {
 
     @Override
     public List<PageLink> getPageLinkList() {
-        // TODO : 좌표를 계산해 left right 페이지의 link 들을 리턴해야함.
-        return null;
+        ArrayList<PageLink> linkList = new ArrayList<>();
+        linkList.addAll(leftPage.getPageLinkList());
+        linkList.addAll(
+                offsetPageLinkList(
+                        rightPage.getPageLinkList(),
+                        leftPage.getSize().width,
+                        0f
+                )
+        );
+        return linkList;
+    }
+
+    private List<PageLink> offsetPageLinkList(List<PageLink> linkList, float offsetX, float offsetY) {
+        ArrayList<PageLink> copiedList = new ArrayList<>(linkList);
+        for (PageLink pageLink : copiedList) {
+            RectF rect = new RectF(pageLink.getBoundingRect());
+            rect.offset(offsetX, offsetY);
+            pageLink.setBoundingRect(rect);
+        }
+        return copiedList;
     }
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
@@ -94,20 +94,19 @@ public class DoublePageContent implements PageContent {
         ArrayList<PageLink> linkList = new ArrayList<>();
         linkList.addAll(leftPage.getPageLinkList());
         linkList.addAll(
-                offsetPageLinkList(
+                verticalOffsetPageLinkList(
                         rightPage.getPageLinkList(),
-                        leftPage.getSize().width,
-                        0f
+                        leftPage.getSize().width
                 )
         );
         return linkList;
     }
 
-    private List<PageLink> offsetPageLinkList(List<PageLink> linkList, float offsetX, float offsetY) {
+    private List<PageLink> verticalOffsetPageLinkList(List<PageLink> linkList, float offsetX) {
         ArrayList<PageLink> copiedList = new ArrayList<>(linkList);
         for (PageLink pageLink : copiedList) {
             RectF rect = new RectF(pageLink.getBoundingRect());
-            rect.offset(offsetX, offsetY);
+            rect.offset(offsetX, 0f);
             pageLink.setBoundingRect(rect);
         }
         return copiedList;

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/DummyPageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/DummyPageContent.java
@@ -2,6 +2,9 @@ package com.ridi.books.viewer.reader.pagecontent;
 
 import android.graphics.Bitmap;
 
+import java.util.ArrayList;
+import java.util.List;
+
 // 두쪽보기에서 한 페이지밖에 없을때 존재하지 않는 페이지를 위한 dummy content
 // 나머지 한 페이지와 같은 크기를 갖도록 함
 class DummyPageContent implements PageContent {
@@ -20,5 +23,10 @@ class DummyPageContent implements PageContent {
     public Bitmap renderToBitmap(int bitmapWidth, int bitmapHeight,
             int startX, int startY, int pageWidth, int pageHeight, boolean forHighQuality) {
         return null;
+    }
+
+    @Override
+    public List<PageLink> getPageLinkList() {
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/DummyPageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/DummyPageContent.java
@@ -26,7 +26,7 @@ class DummyPageContent implements PageContent {
     }
 
     @Override
-    public List<PageLink> getPageLinkList() {
+    public List<Link> getLinkList() {
         return Collections.emptyList();
     }
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/DummyPageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/DummyPageContent.java
@@ -2,7 +2,7 @@ package com.ridi.books.viewer.reader.pagecontent;
 
 import android.graphics.Bitmap;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 // 두쪽보기에서 한 페이지밖에 없을때 존재하지 않는 페이지를 위한 dummy content
@@ -27,6 +27,6 @@ class DummyPageContent implements PageContent {
 
     @Override
     public List<PageLink> getPageLinkList() {
-        return new ArrayList<>();
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/Link.kt
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/Link.kt
@@ -3,4 +3,4 @@ package com.ridi.books.viewer.reader.pagecontent
 import android.graphics.RectF
 import android.net.Uri
 
-data class PageLink(val action: LinkAction, val target: Uri, var boundingRect: RectF)
+data class Link(val action: LinkAction, val target: Uri, var boundingRect: RectF)

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/LinkAction.kt
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/LinkAction.kt
@@ -1,0 +1,6 @@
+package com.ridi.books.viewer.reader.pagecontent
+
+enum class LinkAction {
+    INTERNAL_PAGE,
+    EXTERNAL_URI
+}

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContent.java
@@ -3,9 +3,12 @@ package com.ridi.books.viewer.reader.pagecontent;
 import android.graphics.Bitmap;
 import android.support.annotation.WorkerThread;
 
+import java.util.List;
+
 public interface PageContent {
     SizeF getSize();
     @WorkerThread
     Bitmap renderToBitmap(int bitmapWidth, int bitmapHeight, int startX,
                           int startY, int pageWidth, int pageHeight, boolean forHighQuality);
+    List<PageLink> getPageLinkList();
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContent.java
@@ -10,5 +10,5 @@ public interface PageContent {
     @WorkerThread
     Bitmap renderToBitmap(int bitmapWidth, int bitmapHeight, int startX,
                           int startY, int pageWidth, int pageHeight, boolean forHighQuality);
-    List<PageLink> getPageLinkList();
+    List<Link> getLinkList();
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -1354,4 +1354,12 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
 
         return new Point(view.getLeft(), view.getTop());
     }
+
+    public List<Integer> getVisibleChildIndexList() {
+        ArrayList<Integer> indexList = new ArrayList<>();
+        for (int i = 0; i < childViews.size(); i++) {
+            indexList.add(childViews.keyAt(i));
+        }
+        return indexList;
+    }
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -1356,7 +1356,7 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
     }
 
     public List<Integer> getVisibleChildIndexList() {
-        ArrayList<Integer> indexList = new ArrayList<>();
+        List<Integer> indexList = new ArrayList<>();
         for (int i = 0; i < childViews.size(); i++) {
             indexList.add(childViews.keyAt(i));
         }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -1362,4 +1362,8 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
         }
         return indexList;
     }
+
+    public PageContentView.Size getRenderSize() {
+        return childViews.get(currentIndex).getRenderSize();
+    }
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
@@ -373,4 +373,8 @@ class PageContentView extends ViewGroup {
             return bitmap;
         }
     }
+
+    public Size getRenderSize() {
+        return size;
+    }
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
@@ -322,7 +322,7 @@ class PageContentView extends ViewGroup {
         return index;
     }
     
-    boolean isRendered() {
+    public boolean isRendered() {
         return rendered;
     }
     

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageLink.kt
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageLink.kt
@@ -1,0 +1,6 @@
+package com.ridi.books.viewer.reader.pagecontent
+
+import android.graphics.RectF
+import android.net.Uri
+
+data class PageLink(val action: LinkAction, val target: Uri, val boundingRect: RectF)

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageLink.kt
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageLink.kt
@@ -3,4 +3,4 @@ package com.ridi.books.viewer.reader.pagecontent
 import android.graphics.RectF
 import android.net.Uri
 
-data class PageLink(val action: LinkAction, val target: Uri, val boundingRect: RectF)
+data class PageLink(val action: LinkAction, val target: Uri, var boundingRect: RectF)


### PR DESCRIPTION

## 개요
- page 기반으로 동작하는 컨텐츠에서 link를 다룰 수 있도록 기능 추가

## 작업내용
### kotlin 설정
- 프로젝트에 kotlin이 설정되어있지 않아, kotlin을 설정하였습니다.
### Link 데이터 추가
- Page기반으로 동작하는 컨텐츠를 제공해는 `PageContent`에서 링크와 관련된 값을 받아올수 있도록, `getPageLinkList` 함수 및 관련 객체를 추가하였습니다.
- enum `LinkAction`에서는 아래 2가지 타입을 만들었습니다.
    - 내부 페이지 링크 : INTERNAL_PAGE
    - 외부 페이지 링크 : EXTERNAL_URI
### 두쪽보기
- 두쪽보기 일 경우 PageContent를 가공하는 `DoublePageContent`, `DummyPageContent`에 `getPageLinkList`를 구현하였습니다.
    - DoublePageContent : left page는 그대로, right page는 left width만큼 여백을 추가하여 전달합니다.
    - DummyPageContent : 빈 리스트를 전달합니다.
## 기타
- **리뷰 완료후 새로운 버전으로 배포되어야합니다.**