### PR TITLE
deep copy가 제대로 되지 않는 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'kotlin-android'
 
 group = 'com.github.ridi'
-version = '1.4.0'
+version = '1.4.1'
 
 android {
     compileSdkVersion 28

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/DoublePageContent.java
@@ -103,12 +103,15 @@ public class DoublePageContent implements PageContent {
     }
 
     private List<Link> horizontalOffsetLinkList(List<Link> linkList, float offsetX) {
-        List<Link> copiedList = new ArrayList<>(linkList);
-        for (Link link : copiedList) {
-            RectF rect = new RectF(link.getBoundingRect());
+        List<Link> appendedLinkList = new ArrayList<>();
+        for (Link link : linkList) {
+            Link copiedLink = new Link(link.getAction(), link.getTarget(), link.getBoundingRect());
+            RectF rect = new RectF(copiedLink.getBoundingRect());
             rect.offset(offsetX, 0f);
-            link.setBoundingRect(rect);
+            copiedLink.setBoundingRect(rect);
+
+            appendedLinkList.add(copiedLink);
         }
-        return copiedList;
+        return appendedLinkList;
     }
 }


### PR DESCRIPTION
## 개요
- 두쪽보기에서 링크가 클릭되지 않는 버그가 있음. 
- 관련이슈 : https://app.asana.com/0/1101882213732283/1108584824008327/f

## 원인
- deep copy가 제대로 동작하지 않아 offset이 계속 누적되어 잘못된 좌표값이 처리되고 있었음

## 기타
- merge 이후 새로운 버전으로 배포되어야합니다.