### PR TITLE
childView가 null인 오류 임시대응

### DIFF
--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -1364,6 +1364,13 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
     }
 
     public PageContentView.Size getRenderSize() {
-        return childViews.get(currentIndex).getRenderSize();
+        PageContentView currentView = childViews.get(currentIndex);
+        if (currentView != null) {
+            return childViews.get(currentIndex).getRenderSize();
+        } else {
+            // TODO : 원인 확인 필요
+            // 알 수 없는 이유로 current index가 비어있을경우 사이즈가 같을 가능성이 높은 첫번재 뷰의 값을 리턴함.
+            return childViews.get(childViews.keyAt(0)).getRenderSize();
+        }
     }
 }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -1367,10 +1367,13 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
         PageContentView currentView = childViews.get(currentIndex);
         if (currentView != null) {
             return childViews.get(currentIndex).getRenderSize();
-        } else {
+        } else if (childViews.size() != 0) {
             // TODO : 원인 확인 필요
             // 알 수 없는 이유로 current index가 비어있을경우 사이즈가 같을 가능성이 높은 첫번재 뷰의 값을 리턴함.
             return childViews.get(childViews.keyAt(0)).getRenderSize();
+        } else {
+            // childViews가 완전 비어있을경우 size(1,1)을 리턴함.
+            return new PageContentView.Size(1, 1);
         }
     }
 }


### PR DESCRIPTION
## 개요
- 특정상황에서 childView가 null이라 아래 오류가 발생하는 문제가 있습니다. 
정확한 원인은 파악하지 못해 임시대응 코드를 추가합니다.

## 오류 공통사항
- ~공통적으로 성인물에서 에러가 발생합니다.~
- 공통적으로 `bom` 타입에서 에러가 발생합니다.

## 작업내용
의도적으로 내부 콘텐츠 사이즈를 제각각으로 만들지 않는이상 모든 페이지의 renderSize는 동일합니다.
currentIndex의 childView가 비어있을경우 내부적으로 저장된 첫번째 뷰의 size를 리턴하도록 임시대응하였습니다.

아래상황에선 좌표계산이 오류가 생길 수 있습니다.
'가로모드에서 두쪽보기'가 활성화 되어있고, '첫 페이지부터 두쪽보기'가 비활성화되어있고,
이 오류가 2페이지에서 발생하고, 2페이지에 링크가 존재할경우 
1페이지와 2페이지의 renderSize가 달라 문제가 생길 수 있습니다.
(너무 마이너한 경우라 상관 없을것 같습니다.)

## 기타
원인 파악이 안되고 재현도 안되어 임시대응으로 처리하였습니다. 🙏 
이작업을 진행하지 않고 더 지켜보는게 나을수도 있는데 그점도 검토 부탁드립니다.
