### PR TITLE
가로모드일 때, 무한 스크롤 되는 이슈 수정

### DIFF
--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -523,10 +523,8 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
             // Move to next or previous if current is sufficiently off center
             if (cv != null && scrollMode && !sliding) {
                 cvOffset = subScreenSizeOffset(cv);
-                int height;
-                if (getHeight() >= getWidth()) {
-                    height = getHeight();
-                } else {
+                int height = getHeight();
+                if (getWidth() >= getHeight()) {
                     height = getWidth();
                 }
                 if (cv.getTop() + cv.getMeasuredHeight() + cvOffset.y

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -522,17 +522,12 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
         if (!resetLayout) {
             // Move to next or previous if current is sufficiently off center
             if (cv != null && scrollMode && !sliding) {
-                cvOffset = subScreenSizeOffset(cv);
-                int height = getHeight();
-                if (getWidth() >= getHeight()) {
-                    height = getWidth();
-                }
-                if (cv.getTop() + cv.getMeasuredHeight() + cvOffset.y
-                    + pageGapPixels * scale / 2 + scrollOffsetY < height / 2) {
+                if (cv.getTop() + cv.getMeasuredHeight()
+                    + pageGapPixels * scale / 2 + scrollOffsetY < getHeight() / 2) {
                     setCurrentIndexToRightOrDown();
                 }
-                if (cv.getTop() - cvOffset.y
-                    - pageGapPixels * scale / 2 + scrollOffsetY >= height / 2) {
+                if (cv.getTop()
+                    - pageGapPixels * scale / 2 + scrollOffsetY >= getHeight() / 2) {
                     setCurrentIndexToLeftOrUp();
                 }
             }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -283,16 +283,17 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
     
     private Point subScreenSizeOffset(PageContentView view) {
         int x = Math.max((getWidth() - view.getMeasuredWidth()) / 2, 0);
+        int y = getHeight() - view.getMeasuredHeight();
         if (scrollMode) {
             if ((reverseMode && view.getIndex() == adapter.getCount() - 1)
                     || (!reverseMode && view.getIndex() == 0)) {
                 return new Point(x, 0);
             } else if ((reverseMode && view.getIndex() == 0)
                     || (!reverseMode && view.getIndex() == adapter.getCount() - 1)) {
-                return new Point(x, getHeight() - view.getMeasuredHeight());
+                return new Point(x, y);
             }
         }
-        return new Point(x, Math.max((getHeight() - view.getMeasuredHeight()) / 2, 0));
+        return new Point(x, Math.max(y / 2, 0));
     }
     
     private View getCached() {

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -523,12 +523,18 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
             // Move to next or previous if current is sufficiently off center
             if (cv != null && scrollMode && !sliding) {
                 cvOffset = subScreenSizeOffset(cv);
+                int height;
+                if (getHeight() >= getWidth()) {
+                    height = getHeight();
+                } else {
+                    height = getWidth();
+                }
                 if (cv.getTop() + cv.getMeasuredHeight() + cvOffset.y
-                    + pageGapPixels * scale / 2 + scrollOffsetY < getHeight() / 2) {
+                    + pageGapPixels * scale / 2 + scrollOffsetY < height / 2) {
                     setCurrentIndexToRightOrDown();
                 }
                 if (cv.getTop() - cvOffset.y
-                    - pageGapPixels * scale / 2 + scrollOffsetY >= getHeight() / 2) {
+                    - pageGapPixels * scale / 2 + scrollOffsetY >= height / 2) {
                     setCurrentIndexToLeftOrUp();
                 }
             }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -526,8 +526,7 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
                     + pageGapPixels * scale / 2 + scrollOffsetY < getHeight() / 2) {
                     setCurrentIndexToRightOrDown();
                 }
-                if (cv.getTop()
-                    - pageGapPixels * scale / 2 + scrollOffsetY >= getHeight() / 2) {
+                if (cv.getTop() - pageGapPixels * scale / 2 + scrollOffsetY >= getHeight() / 2) {
                     setCurrentIndexToLeftOrUp();
                 }
             }

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -283,17 +283,16 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
     
     private Point subScreenSizeOffset(PageContentView view) {
         int x = Math.max((getWidth() - view.getMeasuredWidth()) / 2, 0);
-        int y = getHeight() - view.getMeasuredHeight();
         if (scrollMode) {
             if ((reverseMode && view.getIndex() == adapter.getCount() - 1)
                     || (!reverseMode && view.getIndex() == 0)) {
                 return new Point(x, 0);
             } else if ((reverseMode && view.getIndex() == 0)
                     || (!reverseMode && view.getIndex() == adapter.getCount() - 1)) {
-                return new Point(x, y);
+                return new Point(x, getHeight() - view.getMeasuredHeight());
             }
         }
-        return new Point(x, Math.max(y / 2, 0));
+        return new Point(x, Math.max((getHeight() - view.getMeasuredHeight()) / 2, 0));
     }
     
     private View getCached() {


### PR DESCRIPTION
## 개요
- PageContentReaderView 내 가로모드로 책을 이용할 때, 마지막 페이지에서 무한 스크롤이 되는 이슈가 있습니다.

## 문제 원인
- 가로모드에서 마지막 페이지 확인시에 `setCurrentIndexToRightOrDown()` 호출
-  currentIndex가 증가한 이후에 `setCurrentIndexToLeftOrUp()`을 호출하여 currentIndex가 다시 감소 
-  다시 감소한 이후에는 childViews.get(currentIndex)가 null이라 addOnMeasureChild 호출
-  addOnMeasureChild에서 캐싱이 되었던 뷰가 다시 뷰어 하단에 이어붙게 되어 문제가 재현.

## 문제 해결
- 문제가 발생했던 PDF도서와 만화도서에서 이슈가 해결되었음을 확인했습니다.