### PR TITLE
PageContentView를 사용하는 측에서 상속받아 사용할 수 있게 수정

### DIFF
--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentImageView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentImageView.java
@@ -15,7 +15,7 @@ public class PageContentImageView extends View {
     private boolean highQualityView;
     private boolean dirty;
 
-    PageContentImageView(Context context) {
+    public PageContentImageView(Context context) {
         this(context, false);
     }
 

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
@@ -11,27 +11,27 @@ import android.view.ViewGroup;
 public class PageContentView extends ViewGroup {
     static final int NO_INDEX = Integer.MIN_VALUE;
 
-    private int index;
-    private Size canvasSize;
-    @ColorInt private int paperColor;
-    private FitPolicy fitPolicy;
-    private BackgroundTaskListener backgroundTaskListener;
+    protected int index;
+    protected Size canvasSize;
+    @ColorInt protected int paperColor;
+    protected FitPolicy fitPolicy;
+    protected BackgroundTaskListener backgroundTaskListener;
 
-    private Size size;
-    
-    private PageContent pageContent;
-    private AsyncTask<Void, Void, PageContent> contentLoadTask;
+    protected Size size;
 
-    private PageContentImageView fullView;
-    private AsyncTask<Void, Void, Bitmap> fullRenderingTask;
-    private PageContentImageView hqView;  // high quality view
-    private AsyncTask<HighQualityInfo, Void, HighQualityInfo> hqRenderingTask;
-    private HighQualityInfo hqInfo;
-    private BitmapPostProcessor postProcessor;
-    
-    private boolean rendered;
+    protected PageContent pageContent;
+    protected AsyncTask<Void, Void, PageContent> contentLoadTask;
 
-    PageContentView(Context context, int canvasWidth, int canvasHeight, @ColorInt int paperColor,
+    protected PageContentImageView fullView;
+    protected AsyncTask<Void, Void, Bitmap> fullRenderingTask;
+    protected PageContentImageView hqView;  // high quality view
+    protected AsyncTask<HighQualityInfo, Void, HighQualityInfo> hqRenderingTask;
+    protected HighQualityInfo hqInfo;
+    protected BitmapPostProcessor postProcessor;
+
+    protected boolean rendered;
+
+    public PageContentView(Context context, int canvasWidth, int canvasHeight, @ColorInt int paperColor,
                     FitPolicy fitPolicy, BackgroundTaskListener backgroundTaskListener,
                     BitmapPostProcessor postProcessor) {
         this(context, null);
@@ -49,11 +49,11 @@ public class PageContentView extends ViewGroup {
         addView(fullView);
     }
 
-    private PageContentView(Context context, AttributeSet attrs) {
+    public PageContentView(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
 
-    void clear() {
+    protected void clear() {
         index = NO_INDEX;
         if (contentLoadTask != null) {
             contentLoadTask.cancel(true);
@@ -135,8 +135,8 @@ public class PageContentView extends ViewGroup {
             }
         }
     }
-    
-    void loadPageContent(final PageContentProvider provider, final int index) {
+
+    protected void loadPageContent(final PageContentProvider provider, final int index) {
         clear();
 
         this.index = index;
@@ -221,8 +221,8 @@ public class PageContentView extends ViewGroup {
 
         fullRenderingTask.execute();
     }
-    
-    void updateHighQuality() {
+
+    protected void updateHighQuality() {
         Rect viewArea = new Rect(getLeft(), getTop(), getRight(), getBottom());
         
         // If the viewArea's size matches the unzoomed size, there is no need for an hq patch
@@ -298,8 +298,8 @@ public class PageContentView extends ViewGroup {
             hqRenderingTask.execute(new HighQualityInfo(hqSize, hqArea));
         }
     }
-    
-    void removeHighQuality() {
+
+    protected void removeHighQuality() {
         // Stop the rendering of the patch if still going
         if (hqRenderingTask != null) {
             hqRenderingTask.cancel(true);
@@ -311,14 +311,14 @@ public class PageContentView extends ViewGroup {
         hideHqViewIfExists();
     }
 
-    private void hideHqViewIfExists() {
+    protected void hideHqViewIfExists() {
         if (hqView != null) {
             hqView.setImageBitmap(null);
             hqView.setVisibility(INVISIBLE);
         }
     }
 
-    int getIndex() {
+    protected int getIndex() {
         return index;
     }
     
@@ -360,7 +360,7 @@ public class PageContentView extends ViewGroup {
         }
     }
 
-    private abstract class AsyncRenderingTask<Params, Progress, Result>
+    protected abstract class AsyncRenderingTask<Params, Progress, Result>
             extends AsyncTask<Params, Progress, Result> {
         protected Bitmap applyPostProcessor(Bitmap bitmap) {
             if (!isCancelled() && postProcessor != null) {

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentView.java
@@ -6,9 +6,9 @@ import android.graphics.Rect;
 import android.os.AsyncTask;
 import android.support.annotation.ColorInt;
 import android.util.AttributeSet;
-import android.view.ViewGroup;
+import android.widget.FrameLayout;
 
-public class PageContentView extends ViewGroup {
+public class PageContentView extends FrameLayout {
     static final int NO_INDEX = Integer.MIN_VALUE;
 
     protected int index;
@@ -94,6 +94,8 @@ public class PageContentView extends ViewGroup {
     
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
         int width, height;
         
         switch(MeasureSpec.getMode(widthMeasureSpec)) {
@@ -120,6 +122,8 @@ public class PageContentView extends ViewGroup {
 
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+
         int width = right - left;
         int height = bottom - top;
 


### PR DESCRIPTION

## 개요

- PageContentView를 사용하는 측에서 상속받아 사용할 수 있게 수정했습니다. (https://github.com/ridi/pagecontentreaderview/commit/8af4701a82d881390458c2909f507365e3bc5945)
- PageContentView가 FrameLayout을 상속받을 수 있도록 수정했습니다.
(https://github.com/ridi/pagecontentreaderview/commit/46511d6ae7b394f4ef727d1d3a46800034e7c01d)