### PR TITLE
스크롤 모드에서의 이전/다음 페이지 전환 기준 변경

### DIFF
--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -520,7 +520,7 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
         }
 
         if (!resetLayout) {
-            // Move to next or previous if current is sufficiently off center
+            // 콘텐츠가 화면 상단(0)을 벗어나면 다음으로, 화면 하단(height)를 벗어나면 이전으로 이동합니다.
             if (cv != null && scrollMode && !sliding) {
                 if (cv.getTop() + cv.getMeasuredHeight()
                     + pageGapPixels * scale / 2 + scrollOffsetY < 0) {

--- a/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
+++ b/src/main/java/com/ridi/books/viewer/reader/pagecontent/PageContentReaderView.java
@@ -523,10 +523,10 @@ public class PageContentReaderView extends AdapterView<PageContentViewAdapter>
             // Move to next or previous if current is sufficiently off center
             if (cv != null && scrollMode && !sliding) {
                 if (cv.getTop() + cv.getMeasuredHeight()
-                    + pageGapPixels * scale / 2 + scrollOffsetY < getHeight() / 2) {
+                    + pageGapPixels * scale / 2 + scrollOffsetY < 0) {
                     setCurrentIndexToRightOrDown();
                 }
-                if (cv.getTop() - pageGapPixels * scale / 2 + scrollOffsetY >= getHeight() / 2) {
+                if (cv.getTop() - pageGapPixels * scale / 2 + scrollOffsetY >= getHeight()) {
                     setCurrentIndexToLeftOrUp();
                 }
             }


### PR DESCRIPTION
## 개요
- 스크롤 모드에서 페이지(index)가 바뀌는 기준을 변경 하였습니다.
- 기존 방식은 '화면 높이의 중간'을 지나는 것을 기준으로 하여 index를 변경 하였는데요, 콘텐츠의 높이가 '화면 높이의 절반' 보다 작을 경우 의도한 index를 벗어나 움직이는 문제가 있습니다.
    - ex : 만화 첫 진입시 세번째 컷으로 스크롤 되는 문제 : https://app.asana.com/0/19938672055715/1162186261655850/f

## 변경 후
- 컨텐츠가 화면 상단을 지나야 다음 Index로 인식하도록
- 컨텐츠가 화면 하단을 지나야 이전 Index로 인식하도록

변경하였습니다.